### PR TITLE
Carry stateless MCP HTTP task-lifecycle fix locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,17 +22,24 @@ RUN uv build --wheel -o /dist
 FROM python:3.13-slim
 
 # Create non-root user
-RUN useradd -m -u 1001 appuser
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends quilt \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -m -u 1001 appuser
 
 WORKDIR /app
 
 # Copy wheel from builder
 COPY --from=builder /dist/*.whl /dist/requirements.txt /tmp/
+COPY patches/ /tmp/patches/
 
 # Install the wheel and dependencies
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 RUN pip install --no-cache-dir /tmp/dremioai*.whl
-RUN rm /tmp/*.whl /tmp/requirements.txt
+RUN export QUILT_PATCHES=/tmp/patches \
+    && cd / \
+    && quilt push -a \
+    && rm -rf /tmp/patches /tmp/*.whl /tmp/requirements.txt
 
 USER 1001
 

--- a/docs/stateless-http-memory-leak-blog-post.md
+++ b/docs/stateless-http-memory-leak-blog-post.md
@@ -1,0 +1,331 @@
+# Diagnosing a Stateless Streamable HTTP Memory Leak
+
+## Overview
+
+This document captures how we diagnosed a memory leak in stateless MCP Streamable
+HTTP, starting from production-ish memory graphs and ending with a minimal upstream
+patch.
+
+The short version:
+
+- large `RunSqlQuery` responses first exposed the problem
+- fixing our own SQL result handling reduced the symptom but did not eliminate it
+- the real leak turned out to be in the MCP SDK's stateless transport task lifecycle
+- structured tool responses amplified the memory cost, but were not the root cause
+
+## The Initial Symptom
+
+We started with Kubernetes memory graphs showing MCP pods climb from a few hundred MiB
+to multiple GiB and then eventually OOM or get replaced.
+
+At first glance, the obvious suspect was `RunSqlQuery` because it can return large
+payloads and historically built several in-memory copies of the result.
+
+That led to the first round of fixes:
+
+- cap result rows and bytes
+- fetch result pages sequentially
+- remove pandas from the default `RunSqlQuery` MCP response path
+- add metrics for rows, pages, truncation, and response size
+
+Those changes were real improvements, but memory still ratcheted upward under repeated
+large responses.
+
+## First Key Split: Tool Logic vs Transport
+
+We then asked a sharper question:
+
+Is the leak in the tool implementation, or in the MCP transport/serialization layer?
+
+To answer that, we built two soak paths:
+
+1. call `RunSqlQuery.invoke()` directly in-process
+2. call the same tool through MCP Streamable HTTP
+
+The direct invoke path stayed flat.
+The Streamable HTTP path grew.
+
+That separated the problem cleanly:
+
+- tool code was no longer the main leak
+- transport/session/serialization was the real suspect
+
+The RSS-based soak tests were the first hard split:
+
+```text
+direct RunSqlQuery.invoke() soak, 30 iterations
+- rss after gc: 153.7 -> 154.6 -> 154.9 MiB
+- delta: +1.2 MiB
+
+transport soak, 30 iterations
+- rss after gc: 195.7 -> 244.1 -> 273.4 MiB
+- delta: +77.7 MiB from iter 10 to 30
+```
+
+That told us the SQL tool path itself was now basically stable, while the full MCP
+transport path was still retaining memory between calls.
+
+## Structured Content Was an Amplifier
+
+Next we tested whether MCP's result conversion behavior was making the leak more
+expensive.
+
+We ran the same transport soak twice:
+
+- baseline: full `structuredContent` and normal text `content`
+- compact: keep full `structuredContent`, replace text `content` with a tiny summary
+
+The compact variant reduced retained memory growth sharply.
+
+That told us:
+
+- large mirrored text payloads were materially increasing memory cost
+- but the transport path was still holding onto per-request state too long
+
+In other words:
+
+- payload duplication explained "why each leaked request was expensive"
+- it did not explain "why requests were leaking at all"
+
+The compact-content experiment made that visible in one run:
+
+```text
+baseline transport soak, 30 calls
+- rss after gc: 180.4 -> 277.6 MiB
+- delta: +97.2 MiB
+
+compact-content transport soak, 30 calls
+- rss after gc: 242.1 -> 259.4 MiB
+- delta: +17.3 MiB
+```
+
+So reducing the mirrored text payload cut most of the retained memory growth, but it
+still did not eliminate the underlying request-to-request accumulation.
+
+## Memray and Tracemalloc Narrowed the Area
+
+`memray` and `tracemalloc` showed hot spots in:
+
+- pydantic validation/serialization
+- transport buffering
+- SSE-related paths
+- MCP result conversion
+
+That was useful, but allocator hot spots alone do not prove object retention.
+
+So we added GC/task diagnostics and looked for live-object growth instead.
+
+### Tracemalloc Excerpts
+
+`tracemalloc` helped answer an important question: "is this just RSS not returning to
+the OS, or is Python-tracked memory growing too?"
+
+During the leaking transport soak:
+
+```text
+py_current_mb: 14.0 -> 25.4 -> 36.6
+py_peak_mb:    18.1 -> 29.4 -> 40.7
+```
+
+That ruled out a pure allocator-retention explanation. Live Python allocations were
+also increasing.
+
+The top `tracemalloc` diffs between iterations were especially revealing:
+
+```text
++7.6 MiB  pydantic/main.py:782          validate_json
++7.3 MiB  mcp/server/fastmcp/utilities/func_metadata.py:492
++6.4 MiB  pydantic/main.py:475          to_python
+```
+
+That pushed the investigation toward MCP result conversion and pydantic model
+serialization instead of back toward SQL fetching.
+
+### Memray Excerpts
+
+`memray` gave a better view of total allocation pressure and where bytes were being
+spent across the transport path.
+
+Baseline profile:
+
+```text
+total allocated: 1.969 GB
+peak memory:     143.960 MB
+
+top allocators:
+- pydantic/_internal/_repr.py:62   287.988 MB
+- pydantic/main.py:782             250.199 MB
+- asyncio/selector_events.py:1005  237.480 MB
+- sse_starlette/event.py:59         72.617 MB
+- json/encoder.py:261               69.719 MB
+```
+
+Compact-content profile:
+
+```text
+total allocated: 1.416 GB
+peak memory:     129.037 MB
+
+notable drops vs baseline:
+- pydantic/main.py:782     down ~131 MB
+- pydantic/_internal/_repr.py:62 down ~128 MB
+- sse_starlette/event.py:59 disappeared from the top list
+```
+
+That strongly supported the conclusion that duplicated content/serialization was a
+major memory amplifier in the transport path.
+
+## The Strongest Leak Signal: Task Count
+
+The breakthrough came from counting tasks in the session manager's AnyIO task group.
+
+Before the fix, repeated stateless requests caused:
+
+- `mcp.session_manager._task_group._tasks` to grow roughly linearly
+- retained task families to include request-scoped server/session/router tasks
+
+That is a much stronger leak signal than RSS alone, because it identifies a live
+object family whose population grows with requests.
+
+The unit tests made that concrete:
+
+```text
+before fix, stateless standalone repro
+- iter 10: task_count=13
+- iter 20: task_count=23
+- iter 30: task_count=33
+
+before fix, Dremio-backed transport repro
+- iter 10: task_count=13
+- iter 20: task_count=23
+```
+
+And after the request-scoped task-group fix:
+
+```text
+after fix, standalone repro
+- iter 10: task_count=0
+- iter 20: task_count=0
+
+after fix, Dremio-backed transport repro
+- iter 10: task_count=0
+- iter 20: task_count=0
+```
+
+That was the decisive proof that the root issue was task ownership and teardown, not
+just expensive response payloads.
+
+At that point the hypothesis became:
+
+- stateless per-request tasks are being started in the wrong task group
+- the long-lived manager task group is retaining request-scoped work
+
+## Standalone Repro
+
+To prove this was not Dremio-specific, we built a plain FastMCP repro:
+
+- [tests/e2e/test_stateless_mcp_standalone_repro.py](/Users/aniket.kulkarni/ws/github/aniket-s-kulkarni/dremio-mcp/tests/e2e/test_stateless_mcp_standalone_repro.py:1)
+
+That repro:
+
+- uses plain `FastMCP`
+- enables `stateless_http=True`
+- defines one tool returning a large payload
+- runs repeated tool calls through Streamable HTTP
+- samples:
+  - RSS after `gc.collect()`
+  - task count in `session_manager._task_group`
+  - task coroutine type counts
+
+It reproduced the same task growth without any Dremio tooling.
+
+That made it suitable for an upstream bug report and regression test.
+
+## Understanding the Broken Ownership Model
+
+The stateless handler was effectively doing this:
+
+1. create a per-request transport
+2. start `run_stateless_server`
+3. attach it to the session manager's long-lived task group
+4. handle one request
+5. return
+
+This is a structured concurrency bug.
+
+In AnyIO, a task group owns its child tasks until they exit. If per-request tasks are
+started in a process-lifetime task group, then request lifetimes are no longer the
+owner boundary. That makes it easy for request objects to survive too long.
+
+For stateless HTTP, the correct owner boundary is the request itself.
+
+## The Fix
+
+The fix is small and local:
+
+- create a request-scoped AnyIO task group inside `_handle_stateless_request()`
+- start `run_stateless_server` there
+- handle the request
+- cancel and exit the request-scoped group immediately after the response completes
+
+That change is captured in:
+
+- [patches/0001-fix-stateless-streamable-http-task-lifecycle.patch](/Users/aniket.kulkarni/ws/github/aniket-s-kulkarni/dremio-mcp/patches/0001-fix-stateless-streamable-http-task-lifecycle.patch:1)
+
+## Validation
+
+After the fix:
+
+- standalone repro task delta dropped to `0`
+- Dremio-backed repro task delta dropped to `0`
+- RSS remained effectively flat in both cases
+
+A representative after-fix run looked like this:
+
+```text
+standalone repro
+- structured_rss_delta_mb=0.1
+- text_rss_delta_mb=0.1
+- structured_task_delta=0
+- text_task_delta=0
+
+Dremio-backed repro
+- baseline_delta_mb=0.1
+- compact_delta_mb=0.0
+- baseline_task_delta=0
+- compact_task_delta=0
+```
+
+That is the strongest evidence that the root leak mechanism was fixed.
+
+## Separate Local App Issue
+
+We also found a local app-level issue:
+
+- our normal server lifespan started a `_settings_refresh_loop()`
+- in stateless HTTP mode, the SDK creates a fresh `app.run()` task per request
+- so using the normal lifespan created one refresh task per request
+
+We fixed that separately with a no-op stateless lifespan in:
+
+- [mcp.py](/Users/aniket.kulkarni/ws/github/aniket-s-kulkarni/dremio-mcp/src/dremioai/servers/mcp.py:624)
+
+That was worth fixing, but it was not the root SDK leak because the standalone repro
+proved the SDK issue existed without Dremio code.
+
+## What Remains
+
+There are still occasional `sse_starlette` `_shutdown_watcher()` pending-task warnings
+at teardown. Those warnings did not accumulate after the task-group fix, so they look
+like shutdown cleanup noise rather than the main leak.
+
+They are worth a follow-up, but they should be tracked separately from the stateless
+task accumulation bug.
+
+## Lessons
+
+- Fixing big payloads can reduce symptoms without fixing the actual leak.
+- Direct-invoke vs transport-level testing is a powerful split for narrowing blame.
+- Task population is often a better leak indicator than RSS alone.
+- Structured concurrency bugs are really ownership bugs: the wrong parent scope keeps
+  the wrong children alive.

--- a/docs/upstream-stateless-http-fix-summary.md
+++ b/docs/upstream-stateless-http-fix-summary.md
@@ -1,0 +1,105 @@
+# Upstream Patch Summary: Stateless Streamable HTTP Task Lifecycle
+
+## Summary
+
+This patch fixes a memory leak in the MCP Python SDK stateless Streamable HTTP path.
+
+The leak is caused by starting a per-request `run_stateless_server` task inside the
+session manager's long-lived AnyIO task group. In stateless mode, request-scoped
+server tasks should die with the request. Instead, they were being parented by the
+manager-wide task group, which caused task objects and request-linked transport state
+to accumulate across calls.
+
+The fix is small:
+
+- keep the session manager's top-level task group for manager lifecycle only
+- create a fresh request-scoped task group inside `_handle_stateless_request()`
+- start `run_stateless_server` inside that local task group
+- cancel that local group as soon as `http_transport.handle_request(...)` completes
+
+## Root Cause
+
+The original stateless handler did this conceptually:
+
+1. create a new `StreamableHTTPServerTransport`
+2. start `run_stateless_server`
+3. attach that task to `self._task_group`
+4. handle one HTTP request
+5. return
+
+That is the wrong ownership model for stateless requests.
+
+`self._task_group` lives for the entire lifetime of the session manager. Any task
+started there remains reachable through the group's internal task set until the task
+fully exits and the group cleans it up. If teardown is delayed or incomplete, those
+tasks retain request-linked objects, which makes memory usage ratchet upward.
+
+## Fix
+
+The patched code changes `_handle_stateless_request()` to:
+
+```python
+async with anyio.create_task_group() as request_tg:
+    await request_tg.start(run_stateless_server)
+    try:
+        await http_transport.handle_request(scope, receive, send)
+    finally:
+        request_tg.cancel_scope.cancel()
+```
+
+This matches stateless semantics:
+
+- one request
+- one transport
+- one server task
+- one request-scoped task group
+
+When the request finishes, the task group exits and AnyIO guarantees cancellation and
+cleanup of its child tasks.
+
+## Why This Fix Is Correct
+
+- Stateless HTTP should not preserve per-request server tasks across requests.
+- A request-scoped task group gives the correct lifetime boundary.
+- Stateful mode is unchanged because stateful sessions intentionally survive across
+  multiple requests and still belong in the manager-level task group.
+
+## AnyIO / Transport / App Lifecycle Notes
+
+### What is AnyIO?
+
+AnyIO is an async concurrency library that provides structured concurrency on top of
+`asyncio` and `trio`-style concepts. Its task groups are similar to nursery scopes:
+child tasks belong to a parent scope and are cancelled/awaited as that scope exits.
+
+### What does `http_transport.connect()` do?
+
+`http_transport.connect()` opens the internal stream pair used to bridge the HTTP
+transport layer with the MCP server runtime. It yields the `read_stream` and
+`write_stream` consumed by `app.run(...)`.
+
+### What does `app.run(...)` do?
+
+`app.run(...)` is the server's request-processing loop for the connected transport
+streams. In stateless mode, it should live only as long as the single request-bound
+transport connection.
+
+## Validation
+
+Two repros validate the fix:
+
+- standalone FastMCP repro in
+  [tests/e2e/test_stateless_mcp_standalone_repro.py](/Users/aniket.kulkarni/ws/github/aniket-s-kulkarni/dremio-mcp/tests/e2e/test_stateless_mcp_standalone_repro.py:1)
+- Dremio-backed repro in
+  [tests/e2e/test_runsql_transport_retention_repro.py](/Users/aniket.kulkarni/ws/github/aniket-s-kulkarni/dremio-mcp/tests/e2e/test_runsql_transport_retention_repro.py:1)
+
+With the patch:
+
+- task-count growth drops to `0`
+- RSS stays effectively flat across repeated requests
+
+## Remaining Noise
+
+There are still occasional `sse_starlette` `_shutdown_watcher()` pending-task warnings
+at teardown. Those do not accumulate with requests after this fix and appear to be a
+separate shutdown-cleanup concern, not the original leak.

--- a/docs/upstream-stateless-http-issue.md
+++ b/docs/upstream-stateless-http-issue.md
@@ -1,0 +1,116 @@
+# Upstream Issue Draft: Stateless Streamable HTTP Task Accumulation Causes Memory Growth
+
+## Title
+
+Stateless Streamable HTTP starts per-request server tasks in the manager task group, causing task accumulation and memory growth
+
+## Summary
+
+In stateless Streamable HTTP mode, the MCP Python SDK appears to start a fresh
+per-request `run_stateless_server` task inside the session manager's long-lived AnyIO
+task group. Repeated requests cause task objects to accumulate, and retained
+request/response state drives memory growth.
+
+This reproduces without application-specific code using plain `FastMCP`.
+
+## Affected Area
+
+- `mcp/server/streamable_http_manager.py`
+- stateless Streamable HTTP request handling
+
+## Observed Behavior
+
+Under repeated stateless HTTP tool calls:
+
+- `session_manager._task_group._tasks` grows with requests
+- RSS ratchets upward
+- large structured tool results amplify the memory cost
+
+Before patching, the leak signal was strongest in task count, not just RSS.
+
+## Expected Behavior
+
+In stateless mode, per-request server/transport tasks should be torn down when the
+request completes. Task count should stay flat after warmup.
+
+## Standalone Repro
+
+A standalone repro exists here:
+
+- [tests/e2e/test_stateless_mcp_standalone_repro.py](/Users/aniket.kulkarni/ws/github/aniket-s-kulkarni/dremio-mcp/tests/e2e/test_stateless_mcp_standalone_repro.py:1)
+
+Characteristics:
+
+- plain `FastMCP`
+- `stateless_http=True`
+- one large tool response
+- two modes:
+  - `structured`: returns a dict
+  - `text`: returns a JSON string
+- samples:
+  - RSS after `gc.collect()`
+  - `len(mcp.session_manager._task_group._tasks)`
+  - task coroutine name counts
+
+## Repro Command
+
+```bash
+MCP_STATELESS_STANDALONE_ITERS=20 \
+MCP_STATELESS_STANDALONE_SAMPLE_EVERY=10 \
+MCP_STATELESS_STANDALONE_MODE=both \
+uv run pytest tests/e2e/test_stateless_mcp_standalone_repro.py -s
+```
+
+## Root Cause
+
+The stateless handler starts `run_stateless_server` under the manager-wide task group.
+That task group lives for the session manager lifetime, not the request lifetime.
+
+Stateless request tasks therefore have the wrong owner.
+
+If request teardown is delayed or incomplete, the group retains the tasks and the
+objects reachable from them, including request/response/session state.
+
+## Proposed Fix
+
+Use a request-scoped AnyIO task group in `_handle_stateless_request()`:
+
+```python
+async with anyio.create_task_group() as request_tg:
+    await request_tg.start(run_stateless_server)
+    try:
+        await http_transport.handle_request(scope, receive, send)
+    finally:
+        request_tg.cancel_scope.cancel()
+```
+
+This keeps the manager-wide task group for manager lifecycle only and makes
+stateless per-request tasks die with the request.
+
+## Validation After Patch
+
+With the request-scoped task group fix applied locally:
+
+- standalone repro:
+  - `structured_task_delta=0`
+  - `text_task_delta=0`
+  - RSS delta approximately flat
+- Dremio-backed repro:
+  - `baseline_task_delta=0`
+  - `compact_task_delta=0`
+  - RSS delta approximately flat
+
+## Notes on Structured Content
+
+This investigation also found that structured tool responses can be materially more
+expensive than text-only responses because of mirrored content/serialization behavior.
+That increases per-request memory cost, but it is not the root leak mechanism.
+
+Even text-only responses showed the stateless task accumulation before the lifecycle
+fix.
+
+## Additional Observation
+
+There are still occasional `sse_starlette` `_shutdown_watcher()` pending-task warnings
+at teardown after the lifecycle fix. Those warnings do not appear to accumulate with
+requests and may be a separate shutdown cleanup issue.

--- a/patches/0001-fix-stateless-streamable-http-task-lifecycle.patch
+++ b/patches/0001-fix-stateless-streamable-http-task-lifecycle.patch
@@ -1,0 +1,20 @@
+--- a/usr/local/lib/python3.13/site-packages/mcp/server/streamable_http_manager.py
++++ b/usr/local/lib/python3.13/site-packages/mcp/server/streamable_http_manager.py
+@@ -180,11 +180,15 @@
+                     stateless=True,
+                 )
+ 
+-        # Start server in task group
+-        await self._task_group.start(run_stateless_server)
+-
+-        # Handle the HTTP request and return the response
+-        await http_transport.handle_request(scope, receive, send)
++        # Run stateless request servers in a request-scoped task group so they
++        # are torn down as soon as the response is complete.
++        async with anyio.create_task_group() as request_tg:
++            await request_tg.start(run_stateless_server)
++            try:
++                # Handle the HTTP request and return the response
++                await http_transport.handle_request(scope, receive, send)
++            finally:
++                request_tg.cancel_scope.cancel()

--- a/patches/series
+++ b/patches/series
@@ -1,0 +1,1 @@
+0001-fix-stateless-streamable-http-task-lifecycle.patch

--- a/src/dremioai/servers/mcp.py
+++ b/src/dremioai/servers/mcp.py
@@ -33,7 +33,10 @@ from typing import Annotated, Any, Dict, List, Optional, Tuple, Union
 
 import jwt
 import uvicorn
+import anyio
+import inspect
 from click import Choice
+from anyio.abc import TaskStatus
 from mcp.cli.claude import get_claude_config_path
 from mcp.server.auth.json_response import PydanticJSONResponse
 from mcp.server.auth.middleware.auth_context import (
@@ -50,7 +53,9 @@ from mcp.server.lowlevel.server import request_ctx
 from mcp.server.streamable_http import (
     MCP_PROTOCOL_VERSION_HEADER,
     MCP_SESSION_ID_HEADER,
+    StreamableHTTPServerTransport,
 )
+from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from mcp.types import ContentBlock, Tool as MCPTool, ToolAnnotations
 from pydantic import AnyHttpUrl
 from pydantic.networks import AnyUrl
@@ -81,6 +86,64 @@ from dremioai.metrics.tool_metrics import invocation_counter, invocation_duratio
 from dremioai.servers.jwks_verifier import JWKSVerifier, TokenExpiredError
 from dremioai.tools import tools
 from dremioai.tools.tools import ProjectIdMiddleware, secured
+
+
+def _patch_stateless_http_task_lifecycle():
+    """Apply the upstream stateless Streamable HTTP task-lifecycle fix locally.
+
+    Until the MCP Python SDK merges the request-scoped task-group fix, patch the
+    stateless handler in-process so local runs and tests do not rely solely on the
+    Docker image's quilt-applied dependency patch.
+    """
+
+    if getattr(StreamableHTTPSessionManager, "_dremio_stateless_task_patch", False):
+        return
+
+    current = StreamableHTTPSessionManager._handle_stateless_request
+    try:
+        source = inspect.getsource(current)
+    except OSError:
+        source = ""
+
+    if "request_tg" in source and "cancel_scope.cancel" in source:
+        StreamableHTTPSessionManager._dremio_stateless_task_patch = True
+        return
+
+    async def _handle_stateless_request(self, scope: Scope, receive: Receive, send: Send) -> None:
+        self_logger = logging.getLogger("mcp.server.streamable_http_manager")
+        self_logger.debug("Stateless mode: Creating new transport for this request")
+        http_transport = StreamableHTTPServerTransport(
+            mcp_session_id=None,
+            is_json_response_enabled=self.json_response,
+            event_store=None,
+            security_settings=self.security_settings,
+        )
+
+        async def run_stateless_server(
+            *, task_status: TaskStatus[None] = anyio.TASK_STATUS_IGNORED
+        ):
+            async with http_transport.connect() as streams:
+                read_stream, write_stream = streams
+                task_status.started()
+                await self.app.run(
+                    read_stream,
+                    write_stream,
+                    self.app.create_initialization_options(),
+                    stateless=True,
+                )
+
+        async with anyio.create_task_group() as request_tg:
+            await request_tg.start(run_stateless_server)
+            try:
+                await http_transport.handle_request(scope, receive, send)
+            finally:
+                request_tg.cancel_scope.cancel()
+
+    StreamableHTTPSessionManager._handle_stateless_request = _handle_stateless_request
+    StreamableHTTPSessionManager._dremio_stateless_task_patch = True
+
+
+_patch_stateless_http_task_lifecycle()
 
 
 class MCPTransportLoggingMiddleware:
@@ -621,7 +684,12 @@ def init(
     log.logger("init").info(
         f"Initializing MCP server with mode={mode}, mock={mock}, class={mcp_cls.__name__}"
     )
-    opts = {"log_level": "DEBUG", "debug": True, "lifespan": _server_lifespan}
+    lifespan = (
+        _stateless_http_lifespan
+        if transport == Transports.streamable_http
+        else _server_lifespan
+    )
+    opts = {"log_level": "DEBUG", "debug": True, "lifespan": lifespan}
     if transport == Transports.streamable_http:
         opts["stateless_http"] = True
     if port is not None:
@@ -812,6 +880,16 @@ async def _server_lifespan(app: FastMCP):
         yield
     finally:
         task.cancel()
+
+
+@contextlib.asynccontextmanager
+async def _stateless_http_lifespan(_app: FastMCP):
+    """No-op lifespan for stateless streamable HTTP requests.
+
+    The MCP SDK creates a fresh app.run() task per stateless request. Starting
+    background tasks here would create one long-lived task per call.
+    """
+    yield
 
 
 def run_with_metrics_server(

--- a/tests/e2e/test_runsql_transport_referrers.py
+++ b/tests/e2e/test_runsql_transport_referrers.py
@@ -1,0 +1,331 @@
+#
+#  Copyright (C) 2017-2025 Dremio Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import gc
+import inspect
+import os
+import socket
+import subprocess
+import asyncio
+import uuid
+import weakref
+from collections import Counter
+from contextlib import asynccontextmanager
+
+import pytest
+from mcp import ClientSession, types
+from mcp.client.streamable_http import streamablehttp_client
+from mcp.shared.message import SessionMessage
+from mcp.types import CallToolResult, JSONRPCMessage, JSONRPCResponse, TextContent
+
+from dremioai.config import settings
+from dremioai.config.tools import ToolType
+from dremioai.log import set_level
+from dremioai.servers.mcp import Transports, init
+from mocks.http_mock import LARGE_SQL_MARKER, ServerFixture, start_server_with_app
+
+
+def _current_rss_mb() -> float:
+    out = subprocess.check_output(["ps", "-o", "rss=", "-p", str(os.getpid())], text=True)
+    return int(out.strip()) / 1024.0
+
+
+def _reserve_local_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        return sock.getsockname()[1]
+
+
+@asynccontextmanager
+async def _local_streamable_mcp_server(logging_server, logging_level):
+    old = settings.instance()
+    sf = None
+    try:
+        settings.configure(force=True)
+        host = "127.0.0.1"
+        port = _reserve_local_port()
+        config = {
+            "dremio": {
+                "uri": logging_server.url,
+                "project_id": uuid.uuid4(),
+                "pat": "test-pat",
+                "enable_search": True,
+                "metrics_enabled": False,
+                "max_result_rows": 1200,
+                "max_result_bytes": 0,
+            },
+            "tools": {"server_mode": ToolType.FOR_DATA_PATTERNS.name},
+        }
+        settings.set_base_settings(settings.Settings.model_validate(config))
+        settings.write_settings()
+        set_level(logging_level.upper())
+
+        mcp = init(
+            transport=Transports.streamable_http,
+            port=port,
+            mode=settings.instance().tools.server_mode,
+        )
+        app = mcp.streamable_http_app()
+        server, stop_event = start_server_with_app(
+            app,
+            host=host,
+            port=port,
+            log_level=logging_level,
+        )
+        sf = ServerFixture(f"http://{host}:{port}/mcp/", stop_event, server)
+        yield sf, mcp
+    finally:
+        if sf is not None:
+            sf.close()
+        settings.set_base_settings(old)
+
+
+@asynccontextmanager
+async def _local_streamable_client(server_fixture: ServerFixture, token="my-token"):
+    headers = {"Authorization": f"Bearer {token}"}
+    async with streamablehttp_client(url=server_fixture.url, headers=headers) as (
+        read_stream,
+        write_stream,
+        _gid,
+    ):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            yield session
+
+
+def _alive(refs):
+    return [r() for r in refs if r() is not None]
+
+
+def _heap_type_counts(text_threshold: int):
+    counts = Counter()
+    samples = {}
+    for obj in gc.get_objects():
+        if isinstance(obj, TextContent) and len(obj.text) >= text_threshold:
+            counts["TextContent.large"] += 1
+            samples.setdefault("TextContent.large", obj)
+        elif isinstance(obj, CallToolResult):
+            counts["CallToolResult"] += 1
+            samples.setdefault("CallToolResult", obj)
+        elif isinstance(obj, SessionMessage):
+            counts["SessionMessage"] += 1
+            samples.setdefault("SessionMessage", obj)
+        elif isinstance(obj, JSONRPCResponse):
+            counts["JSONRPCResponse"] += 1
+            samples.setdefault("JSONRPCResponse", obj)
+        elif isinstance(obj, JSONRPCMessage):
+            counts["JSONRPCMessage"] += 1
+            samples.setdefault("JSONRPCMessage", obj)
+        elif isinstance(obj, asyncio.Task):
+            name = getattr(obj.get_coro(), "__name__", type(obj.get_coro()).__name__)
+            counts[f"Task.{name}"] += 1
+            samples.setdefault(f"Task.{name}", obj)
+    return counts, samples
+
+
+def _track_server_tool_results(mcp_server, calltool_refs, text_refs):
+    original = mcp_server._mcp_server.request_handlers[types.CallToolRequest]
+
+    async def wrapped(req):
+        result = await original(req)
+        if isinstance(result, types.ServerResult) and isinstance(result.root, types.CallToolResult):
+            root = result.root
+            calltool_refs.append(weakref.ref(root))
+            for content in root.content:
+                if isinstance(content, TextContent):
+                    text_refs.append(weakref.ref(content))
+        return result
+
+    mcp_server._mcp_server.request_handlers[types.CallToolRequest] = wrapped
+    return original
+
+
+def _describe_object(obj):
+    t = type(obj)
+    if isinstance(obj, TextContent):
+        return f"TextContent(len={len(obj.text)})"
+    if isinstance(obj, CallToolResult):
+        content_len = len(obj.content)
+        return f"CallToolResult(content={content_len}, structured={obj.structuredContent is not None})"
+    if isinstance(obj, JSONRPCResponse):
+        return f"JSONRPCResponse(id={obj.id})"
+    if isinstance(obj, JSONRPCMessage):
+        return f"JSONRPCMessage(root={type(obj.root).__name__})"
+    if isinstance(obj, SessionMessage):
+        return f"SessionMessage(message={type(obj.message.root).__name__})"
+    if isinstance(obj, dict):
+        keys = list(obj.keys())[:5]
+        return f"dict(keys={keys})"
+    if isinstance(obj, list):
+        return f"list(len={len(obj)})"
+    if isinstance(obj, tuple):
+        return f"tuple(len={len(obj)})"
+    if inspect.isframe(obj):
+        return f"frame({obj.f_code.co_name} {obj.f_code.co_filename}:{obj.f_lineno})"
+    if inspect.iscoroutine(obj):
+        return f"coroutine({obj.cr_code.co_name} {obj.cr_code.co_filename}:{obj.cr_code.co_firstlineno})"
+    if inspect.isgenerator(obj):
+        return f"generator({obj.gi_code.co_name})"
+    if isinstance(obj, asyncio.Task):
+        coro = obj.get_coro()
+        code = getattr(coro, "cr_code", None)
+        if code is not None:
+            return f"Task({code.co_name} {code.co_filename}:{code.co_firstlineno})"
+        return "Task"
+    return t.__name__
+
+
+def _owner_summary(container, exclude_ids):
+    owners = [
+        r
+        for r in gc.get_referrers(container)
+        if id(r) not in exclude_ids and not inspect.isframe(r) and not inspect.ismodule(r)
+    ]
+    counts = Counter(type(r).__name__ for r in owners)
+    samples = [_describe_object(r) for r in owners[:5]]
+    return counts, samples
+
+
+def _collect_excluded_ids():
+    excluded = set()
+    frame = inspect.currentframe()
+    depth = 0
+    while frame is not None and depth < 12:
+        excluded.add(id(frame))
+        excluded.add(id(frame.f_locals))
+        for value in frame.f_locals.values():
+            excluded.add(id(value))
+            if isinstance(value, (list, tuple, dict, set)):
+                excluded.add(id(value))
+        frame = frame.f_back
+        depth += 1
+    return excluded
+
+
+def _print_referrer_summary(obj, label):
+    exclude_ids = _collect_excluded_ids()
+    refs = [
+        r
+        for r in gc.get_referrers(obj)
+        if id(r) not in exclude_ids
+        and not inspect.isframe(r)
+        and not inspect.ismodule(r)
+        and not inspect.iscoroutine(r)
+    ]
+    print(f"{label} object={_describe_object(obj)}")
+    print(f"{label} direct_referrer_counts={dict(Counter(type(r).__name__ for r in refs).most_common(10))}")
+    for idx, ref in enumerate(refs[:8], start=1):
+        print(f"{label} ref[{idx}]={_describe_object(ref)}")
+        if isinstance(ref, (list, dict, tuple)):
+            counts, samples = _owner_summary(ref, exclude_ids | {id(obj), id(ref)})
+            print(f"{label} ref[{idx}] owners={dict(counts.most_common(8))}")
+            for sample in samples[:4]:
+                print(f"{label} ref[{idx}] owner_sample={sample}")
+
+
+@pytest.mark.asyncio
+async def test_run_sql_query_transport_referrers(
+    mock_config_dir, logging_server, logging_level
+):
+    iterations = int(os.getenv("RUNSQL_TRANSPORT_REF_ITERS", "0"))
+    if iterations <= 0:
+        pytest.skip("Set RUNSQL_TRANSPORT_REF_ITERS to run the transport referrer diagnostic")
+
+    sample_every = int(os.getenv("RUNSQL_TRANSPORT_REF_SAMPLE_EVERY", "10"))
+    text_threshold = int(os.getenv("RUNSQL_TRANSPORT_REF_TEXT_THRESHOLD", "10000"))
+
+    server_calltool_refs = []
+    server_text_refs = []
+    client_calltool_refs = []
+    client_text_refs = []
+
+    async with _local_streamable_mcp_server(logging_server, logging_level) as (sf, mcp):
+        original = _track_server_tool_results(mcp, server_calltool_refs, server_text_refs)
+        try:
+            async with _local_streamable_client(sf, token="my-token") as session:
+                for i in range(1, iterations + 1):
+                    result = await session.call_tool(
+                        "RunSqlQuery",
+                        {"query": f"SELECT 1 /* {LARGE_SQL_MARKER} */"},
+                    )
+                    client_calltool_refs.append(weakref.ref(result))
+                    for content in result.content:
+                        if isinstance(content, TextContent):
+                            client_text_refs.append(weakref.ref(content))
+
+                    payload = result.structuredContent["result"]
+                    assert len(payload["result"]) == 1200
+                    del payload
+                    del result
+
+                    if i % sample_every == 0:
+                        rss_before_gc = _current_rss_mb()
+                        collected = gc.collect()
+                        rss_after_gc = _current_rss_mb()
+                        alive_server_calltool = _alive(server_calltool_refs)
+                        alive_server_text = [
+                            obj
+                            for obj in _alive(server_text_refs)
+                            if isinstance(obj, TextContent) and len(obj.text) >= text_threshold
+                        ]
+                        alive_client_calltool = _alive(client_calltool_refs)
+                        alive_client_text = [
+                            obj
+                            for obj in _alive(client_text_refs)
+                            if isinstance(obj, TextContent) and len(obj.text) >= text_threshold
+                        ]
+
+                        sample = {
+                            "iter": i,
+                            "rss_before_gc_mb": round(rss_before_gc, 1),
+                            "rss_after_gc_mb": round(rss_after_gc, 1),
+                            "gc_collected": collected,
+                            "alive_server_calltool": len(alive_server_calltool),
+                            "alive_server_large_text": len(alive_server_text),
+                            "alive_client_calltool": len(alive_client_calltool),
+                            "alive_client_large_text": len(alive_client_text),
+                        }
+                        heap_counts, heap_samples = _heap_type_counts(text_threshold)
+                        print(f"REF sample={sample}")
+                        print(f"REF heap_counts={dict(heap_counts)}")
+
+                        if alive_server_calltool:
+                            _print_referrer_summary(alive_server_calltool[0], "REF server_calltool")
+                        if alive_server_text:
+                            _print_referrer_summary(alive_server_text[0], "REF server_text")
+                        if alive_client_calltool:
+                            _print_referrer_summary(alive_client_calltool[0], "REF client_calltool")
+                        if alive_client_text:
+                            _print_referrer_summary(alive_client_text[0], "REF client_text")
+                        if "JSONRPCResponse" in heap_samples:
+                            _print_referrer_summary(heap_samples["JSONRPCResponse"], "REF jsonrpc_response")
+                        if "SessionMessage" in heap_samples:
+                            _print_referrer_summary(heap_samples["SessionMessage"], "REF session_message")
+                        interesting_task_keys = [
+                            "Task._receive_loop",
+                            "Task._settings_refresh_loop",
+                            "Task.run_stateless_server",
+                            "Task.message_router",
+                            "Task.handle_request_async",
+                            "Task._shutdown_watcher",
+                        ]
+                        for task_key in interesting_task_keys:
+                            if task_key not in heap_samples:
+                                continue
+                            _print_referrer_summary(heap_samples[task_key], f"REF {task_key}")
+        finally:
+            mcp._mcp_server.request_handlers[types.CallToolRequest] = original

--- a/tests/e2e/test_runsql_transport_retention_repro.py
+++ b/tests/e2e/test_runsql_transport_retention_repro.py
@@ -1,0 +1,228 @@
+#
+#  Copyright (C) 2017-2025 Dremio Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import gc
+import os
+import socket
+import subprocess
+import uuid
+from collections import Counter
+from contextlib import asynccontextmanager
+
+import pytest
+from mcp import types
+from mcp.types import CallToolResult, TextContent
+
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+from dremioai.config import settings
+from dremioai.config.tools import ToolType
+from dremioai.log import set_level
+from dremioai.servers.mcp import Transports, init
+from mocks.http_mock import ServerFixture, start_server_with_app
+from mocks.http_mock import LARGE_SQL_MARKER
+
+
+def _current_rss_mb() -> float:
+    out = subprocess.check_output(["ps", "-o", "rss=", "-p", str(os.getpid())], text=True)
+    return int(out.strip()) / 1024.0
+
+
+def _reserve_local_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        return sock.getsockname()[1]
+
+
+@asynccontextmanager
+async def _local_streamable_mcp_server(logging_server, logging_level):
+    old = settings.instance()
+    sf = None
+    try:
+        settings.configure(force=True)
+        host = "127.0.0.1"
+        port = _reserve_local_port()
+        config = {
+            "dremio": {
+                "uri": logging_server.url,
+                "project_id": uuid.uuid4(),
+                "pat": "test-pat",
+                "enable_search": True,
+                "metrics_enabled": False,
+                "max_result_rows": 1200,
+                "max_result_bytes": 0,
+            },
+            "tools": {"server_mode": ToolType.FOR_DATA_PATTERNS.name},
+        }
+        settings.set_base_settings(settings.Settings.model_validate(config))
+        settings.write_settings()
+        set_level(logging_level.upper())
+
+        mcp = init(
+            transport=Transports.streamable_http,
+            port=port,
+            mode=settings.instance().tools.server_mode,
+        )
+        app = mcp.streamable_http_app()
+        server, stop_event = start_server_with_app(
+            app,
+            host=host,
+            port=port,
+            log_level=logging_level,
+        )
+        sf = ServerFixture(f"http://{host}:{port}/mcp/", stop_event, server)
+        yield sf, mcp
+    finally:
+        if sf is not None:
+            sf.close()
+        settings.set_base_settings(old)
+
+
+@asynccontextmanager
+async def _local_streamable_client(server_fixture: ServerFixture, token="my-token"):
+    headers = {"Authorization": f"Bearer {token}"}
+    async with streamablehttp_client(url=server_fixture.url, headers=headers) as (
+        read_stream,
+        write_stream,
+        _gid,
+    ):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            yield session
+
+
+def _with_compact_content(mcp_server):
+    original = mcp_server._mcp_server.request_handlers[types.CallToolRequest]
+
+    async def wrapped(req):
+        result = await original(req)
+        if not isinstance(result, types.ServerResult):
+            return result
+
+        root = result.root
+        if not isinstance(root, types.CallToolResult) or root.structuredContent is None:
+            return result
+
+        return types.ServerResult(
+            types.CallToolResult(
+                content=[TextContent(type="text", text="structured response omitted")],
+                structuredContent=root.structuredContent,
+                isError=root.isError,
+                meta=root.meta,
+            )
+        )
+
+    mcp_server._mcp_server.request_handlers[types.CallToolRequest] = wrapped
+    return original
+
+
+def _task_group_counts(mcp) -> tuple[int, dict[str, int]]:
+    tasks = list(mcp.session_manager._task_group._tasks)
+    counts = Counter()
+    for task in tasks:
+        coro = task.get_coro()
+        code = getattr(coro, "cr_code", None)
+        name = code.co_name if code is not None else type(coro).__name__
+        counts[name] += 1
+    return len(tasks), dict(sorted(counts.items()))
+
+
+async def _run_soak(session, mcp, iterations: int, sample_every: int, label: str):
+    samples = []
+
+    for i in range(1, iterations + 1):
+        result: CallToolResult = await session.call_tool(
+            "RunSqlQuery",
+            {"query": f"SELECT 1 /* {LARGE_SQL_MARKER} */"},
+        )
+        assert result is not None and result.structuredContent is not None
+        payload = result.structuredContent["result"]
+        assert len(payload["result"]) == 1200
+        del payload
+        del result
+
+        if i % sample_every == 0:
+            rss_before_gc = _current_rss_mb()
+            collected = gc.collect()
+            rss_after_gc = _current_rss_mb()
+            task_count, task_types = _task_group_counts(mcp)
+            sample = {
+                "iter": i,
+                "rss_before_gc_mb": round(rss_before_gc, 1),
+                "rss_after_gc_mb": round(rss_after_gc, 1),
+                "gc_collected": collected,
+                "task_count": task_count,
+                "task_types": task_types,
+            }
+            samples.append(sample)
+            print(f"{label} sample={sample}")
+
+    return samples
+
+
+@pytest.mark.asyncio
+async def test_run_sql_query_transport_retention_repro(
+    mock_config_dir, logging_server, logging_level
+):
+    iterations = int(os.getenv("RUNSQL_TRANSPORT_REPRO_ITERS", "0"))
+    if iterations <= 0:
+        pytest.skip("Set RUNSQL_TRANSPORT_REPRO_ITERS to run the transport retention repro")
+
+    sample_every = int(os.getenv("RUNSQL_TRANSPORT_REPRO_SAMPLE_EVERY", "10"))
+    mode = os.getenv("RUNSQL_TRANSPORT_REPRO_MODE", "both")
+    assert mode in {"baseline", "compact", "both"}
+
+    baseline = []
+    compact = []
+
+    if mode in {"baseline", "both"}:
+        async with _local_streamable_mcp_server(logging_server, logging_level) as (sf, mcp):
+            async with _local_streamable_client(sf, token="my-token") as session:
+                baseline = await _run_soak(
+                    session, mcp, iterations, sample_every, "TRANSPORT BASELINE"
+                )
+
+    if mode in {"compact", "both"}:
+        async with _local_streamable_mcp_server(logging_server, logging_level) as (sf, mcp):
+            original = _with_compact_content(mcp)
+            try:
+                async with _local_streamable_client(sf, token="my-token") as session:
+                    compact = await _run_soak(
+                        session, mcp, iterations, sample_every, "TRANSPORT COMPACT"
+                    )
+            finally:
+                mcp._mcp_server.request_handlers[types.CallToolRequest] = original
+
+    if baseline:
+        print(f"TRANSPORT BASELINE samples={baseline}")
+    if compact:
+        print(f"TRANSPORT COMPACT samples={compact}")
+
+    if mode == "both" and baseline and compact:
+        baseline_delta = baseline[-1]["rss_after_gc_mb"] - baseline[0]["rss_after_gc_mb"]
+        compact_delta = compact[-1]["rss_after_gc_mb"] - compact[0]["rss_after_gc_mb"]
+        baseline_task_delta = baseline[-1]["task_count"] - baseline[0]["task_count"]
+        compact_task_delta = compact[-1]["task_count"] - compact[0]["task_count"]
+        print(
+            "TRANSPORT RETENTION summary "
+            f"baseline_delta_mb={baseline_delta:.1f} compact_delta_mb={compact_delta:.1f} "
+            f"baseline_task_delta={baseline_task_delta} compact_task_delta={compact_task_delta}"
+        )
+        assert baseline_delta > compact_delta
+        assert baseline_task_delta == 0
+        assert compact_task_delta == 0

--- a/tests/e2e/test_stateless_mcp_standalone_repro.py
+++ b/tests/e2e/test_stateless_mcp_standalone_repro.py
@@ -1,0 +1,201 @@
+#
+#  Copyright (C) 2017-2025 Dremio Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import gc
+import json
+import os
+import socket
+import subprocess
+from collections import Counter
+from contextlib import asynccontextmanager
+
+import pytest
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+from mcp.server.fastmcp import FastMCP
+
+from mocks.http_mock import ServerFixture, start_server_with_app
+
+
+ROW_COUNT = 1200
+PAYLOAD_WIDTH = 256
+
+
+def _current_rss_mb() -> float:
+    out = subprocess.check_output(["ps", "-o", "rss=", "-p", str(os.getpid())], text=True)
+    return int(out.strip()) / 1024.0
+
+
+def _reserve_local_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        return sock.getsockname()[1]
+
+
+def _large_payload() -> dict:
+    return {
+        "result": [
+            {"row_id": idx, "payload": f"row-{idx}-" + ("x" * PAYLOAD_WIDTH)}
+            for idx in range(ROW_COUNT)
+        ]
+    }
+
+
+def _task_group_counts(mcp) -> tuple[int, dict[str, int]]:
+    tasks = list(mcp.session_manager._task_group._tasks)
+    counts = Counter()
+    for task in tasks:
+        coro = task.get_coro()
+        code = getattr(coro, "cr_code", None)
+        name = code.co_name if code is not None else type(coro).__name__
+        counts[name] += 1
+    return len(tasks), dict(sorted(counts.items()))
+
+
+def _build_server(mode: str) -> FastMCP:
+    mcp = FastMCP(
+        "StandaloneLeakRepro",
+        stateless_http=True,
+        debug=True,
+        log_level="DEBUG",
+    )
+
+    if mode == "structured":
+        async def large_payload_tool():
+            return _large_payload()
+    elif mode == "text":
+        async def large_payload_tool():
+            return json.dumps(_large_payload())
+    else:
+        raise ValueError(f"Unsupported mode: {mode}")
+
+    mcp.add_tool(
+        large_payload_tool,
+        name="LargePayload",
+        description="Return a large payload for stateless transport leak repro",
+    )
+    return mcp
+
+
+@asynccontextmanager
+async def _local_streamable_server(mode: str):
+    sf = None
+    host = "127.0.0.1"
+    port = _reserve_local_port()
+    mcp = _build_server(mode)
+    app = mcp.streamable_http_app()
+    server, stop_event = start_server_with_app(
+        app,
+        host=host,
+        port=port,
+        log_level="warning",
+        name=f"standalone-{mode}-mcp-server",
+    )
+    try:
+        sf = ServerFixture(f"http://{host}:{port}/mcp/", stop_event, server)
+        yield sf, mcp
+    finally:
+        if sf is not None:
+            sf.close()
+
+
+@asynccontextmanager
+async def _local_streamable_client(server_fixture: ServerFixture):
+    async with streamablehttp_client(url=server_fixture.url) as (
+        read_stream,
+        write_stream,
+        _gid,
+    ):
+        async with ClientSession(read_stream, write_stream) as session:
+            await session.initialize()
+            yield session
+
+
+async def _run_soak(session, mcp, iterations: int, sample_every: int, label: str):
+    samples = []
+
+    for i in range(1, iterations + 1):
+        result = await session.call_tool("LargePayload", {})
+        if result.structuredContent is not None:
+            assert len(result.structuredContent["result"]) == ROW_COUNT
+        else:
+            assert result.content and ROW_COUNT > 0
+        del result
+
+        if i % sample_every == 0:
+            gc_collected = gc.collect()
+            rss_after_gc = _current_rss_mb()
+            task_count, task_types = _task_group_counts(mcp)
+            sample = {
+                "iter": i,
+                "rss_after_gc_mb": round(rss_after_gc, 1),
+                "gc_collected": gc_collected,
+                "task_count": task_count,
+                "task_types": task_types,
+            }
+            samples.append(sample)
+            print(f"{label} sample={sample}")
+
+    return samples
+
+
+@pytest.mark.asyncio
+async def test_stateless_streamable_http_standalone_repro():
+    iterations = int(os.getenv("MCP_STATELESS_STANDALONE_ITERS", "0"))
+    if iterations <= 0:
+        pytest.skip("Set MCP_STATELESS_STANDALONE_ITERS to run the standalone stateless repro")
+
+    sample_every = int(os.getenv("MCP_STATELESS_STANDALONE_SAMPLE_EVERY", "10"))
+    mode = os.getenv("MCP_STATELESS_STANDALONE_MODE", "both")
+    assert mode in {"structured", "text", "both"}
+
+    structured = []
+    text = []
+
+    if mode in {"structured", "both"}:
+        async with _local_streamable_server("structured") as (sf, mcp):
+            async with _local_streamable_client(sf) as session:
+                structured = await _run_soak(
+                    session, mcp, iterations, sample_every, "STANDALONE STRUCTURED"
+                )
+
+    if mode in {"text", "both"}:
+        async with _local_streamable_server("text") as (sf, mcp):
+            async with _local_streamable_client(sf) as session:
+                text = await _run_soak(session, mcp, iterations, sample_every, "STANDALONE TEXT")
+
+    if structured:
+        print(f"STANDALONE STRUCTURED samples={structured}")
+    if text:
+        print(f"STANDALONE TEXT samples={text}")
+
+    if mode == "both" and structured and text:
+        structured_rss_delta = (
+            structured[-1]["rss_after_gc_mb"] - structured[0]["rss_after_gc_mb"]
+        )
+        text_rss_delta = text[-1]["rss_after_gc_mb"] - text[0]["rss_after_gc_mb"]
+        structured_task_delta = structured[-1]["task_count"] - structured[0]["task_count"]
+        text_task_delta = text[-1]["task_count"] - text[0]["task_count"]
+        print(
+            "STANDALONE summary "
+            f"structured_rss_delta_mb={structured_rss_delta:.1f} "
+            f"text_rss_delta_mb={text_rss_delta:.1f} "
+            f"structured_task_delta={structured_task_delta} "
+            f"text_task_delta={text_task_delta}"
+        )
+        assert structured_task_delta == 0
+        assert text_task_delta == 0

--- a/tests/tools/test_runsql_direct_soak.py
+++ b/tests/tools/test_runsql_direct_soak.py
@@ -1,0 +1,115 @@
+#
+#  Copyright (C) 2017-2025 Dremio Corporation
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+import gc
+import os
+import subprocess
+import tracemalloc
+import uuid
+
+import pytest
+
+from dremioai.config import settings
+from dremioai.tools.tools import RunSqlQuery
+from mocks.http_mock import LARGE_SQL_MARKER
+
+
+def _current_rss_mb() -> float:
+    out = subprocess.check_output(["ps", "-o", "rss=", "-p", str(os.getpid())], text=True)
+    return int(out.strip()) / 1024.0
+
+
+@pytest.mark.asyncio
+async def test_run_sql_query_direct_soak(mock_config_dir, logging_server):
+    iterations = int(os.getenv("RUNSQL_DIRECT_SOAK_ITERS", "0"))
+    if iterations <= 0:
+        pytest.skip("Set RUNSQL_DIRECT_SOAK_ITERS to run the direct RunSqlQuery soak test")
+
+    sample_every = int(os.getenv("RUNSQL_DIRECT_SOAK_SAMPLE_EVERY", "10"))
+    enable_profile = os.getenv("RUNSQL_DIRECT_SOAK_PROFILE", "0") == "1"
+    samples = []
+    snapshot_start = None
+    snapshot_end = None
+
+    settings.set_base_settings(
+        settings.Settings.model_validate(
+            {
+                "dremio": {
+                    "uri": logging_server.url,
+                    "project_id": uuid.uuid4(),
+                    "pat": "test-pat",
+                    "enable_search": True,
+                    "max_result_rows": 1200,
+                    "max_result_bytes": 0,
+                },
+                "tools": {"server_mode": "FOR_DATA_PATTERNS"},
+            }
+        )
+    )
+
+    if enable_profile:
+        tracemalloc.start(25)
+
+    try:
+        tool = RunSqlQuery()
+        for i in range(1, iterations + 1):
+            result = await tool.invoke(f"SELECT 1 /* {LARGE_SQL_MARKER} */")
+            assert len(result["result"]) == 1200
+            del result
+
+            if i % sample_every == 0:
+                rss_before_gc = _current_rss_mb()
+                collected = gc.collect()
+                rss_after_gc = _current_rss_mb()
+                if enable_profile:
+                    current, peak = tracemalloc.get_traced_memory()
+                    sample = {
+                        "iter": i,
+                        "rss_before_gc_mb": round(rss_before_gc, 1),
+                        "rss_after_gc_mb": round(rss_after_gc, 1),
+                        "py_current_mb": round(current / 1024 / 1024, 1),
+                        "py_peak_mb": round(peak / 1024 / 1024, 1),
+                        "gc_collected": collected,
+                    }
+                    if snapshot_start is None:
+                        snapshot_start = tracemalloc.take_snapshot()
+                    snapshot_end = tracemalloc.take_snapshot()
+                else:
+                    sample = {
+                        "iter": i,
+                        "rss_before_gc_mb": round(rss_before_gc, 1),
+                        "rss_after_gc_mb": round(rss_after_gc, 1),
+                        "gc_collected": collected,
+                    }
+                samples.append(sample)
+                print(f"DIRECT SOAK sample={sample}")
+    finally:
+        if enable_profile:
+            if snapshot_start is not None and snapshot_end is not None:
+                print("DIRECT SOAK tracemalloc_top_diffs")
+                for stat in snapshot_end.compare_to(snapshot_start, "lineno")[:15]:
+                    print(stat)
+            tracemalloc.stop()
+
+    print(f"DIRECT SOAK samples={samples}")
+    if samples:
+        start = samples[0]["rss_after_gc_mb"]
+        end = samples[-1]["rss_after_gc_mb"]
+        peak = max(v["rss_after_gc_mb"] for v in samples)
+        print(
+            "DIRECT SOAK summary "
+            f"start_mb={start:.1f} end_mb={end:.1f} peak_mb={peak:.1f} delta_mb={end-start:.1f}"
+        )


### PR DESCRIPTION
## Summary
- carry the stateless Streamable HTTP request-scoped task-group fix locally in dremio-mcp
- package the upstream MCP patch under patches/ and apply it in Docker with quilt
- add standalone and Dremio-backed diagnostics plus upstream-ready issue and patch docs

## Testing
- UV_CACHE_DIR=/tmp/uv-cache MCP_STATELESS_STANDALONE_ITERS=20 MCP_STATELESS_STANDALONE_SAMPLE_EVERY=10 MCP_STATELESS_STANDALONE_MODE=both RUNSQL_TRANSPORT_REPRO_ITERS=20 RUNSQL_TRANSPORT_REPRO_SAMPLE_EVERY=10 RUNSQL_TRANSPORT_REPRO_MODE=both RUNSQL_DIRECT_SOAK_ITERS=20 RUNSQL_DIRECT_SOAK_SAMPLE_EVERY=10 RUNSQL_TRANSPORT_REF_ITERS=10 RUNSQL_TRANSPORT_REF_SAMPLE_EVERY=10 uv run pytest tests/e2e/test_stateless_mcp_standalone_repro.py tests/e2e/test_runsql_transport_retention_repro.py tests/tools/test_runsql_direct_soak.py tests/e2e/test_runsql_transport_referrers.py -s